### PR TITLE
Deprecate pc_status in favor of cb_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Only major versions or things to communicate are written here. Minor changes or bug fixes might not appear in the changelog.
 
+## 3.1.0
+
+Introduces `cb_status` as the preferred Crawlbase status field and deprecates `pc_status`.  
+Both names are dual-written on responses so existing code continues to work; migrate to `cb_status`. `pc_status` will be removed in a future major version.
+
 ## 3.0.0
 
 Adds Screenshots API and Storage API.  

--- a/README.md
+++ b/README.md
@@ -324,4 +324,4 @@ If you have questions or need help using the library, please open an issue or [c
 
 ---
 
-Copyright 2025 Crawlbase
+Copyright 2026 Crawlbase

--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ You can always get the original status and crawlbase status from the response. R
 ```php
 $response = $api->get('https://craiglist.com');
 echo $response->headers->original_status . PHP_EOL;
-echo $response->headers->pc_status . PHP_EOL;
+echo $response->headers->cb_status . PHP_EOL;
 ```
 
+`pc_status` is still available as a deprecated alias for `cb_status` and will be removed in a future major version.
 ## Scraper API
 
 First initialize the ScraperAPI class. You can [get your free token here](https://crawlbase.com/signup?signup=github). Please note that only some websites are supported, check the [API documentation](https://crawlbase.com/docs/scraper-api/) for more information.
@@ -238,7 +239,7 @@ echo 'status code: ' . $response->statusCode . PHP_EOL;
 if ($response->statusCode === 200) {
   echo 'body: ' . $response->body . PHP_EOL;
   echo 'original status: ' . $response->headers->original_status . PHP_EOL;
-  echo 'crawlbase status: ' . $response->headers->pc_status . PHP_EOL;
+  echo 'crawlbase status: ' . $response->headers->cb_status . PHP_EOL;
   echo 'rid: ' . $response->headers->rid . PHP_EOL;
   echo 'url: ' . $response->headers->url . PHP_EOL;
   echo 'stored date: ' . $response->headers->stored_at . PHP_EOL;
@@ -254,7 +255,7 @@ echo 'status code: ' . $response->statusCode . PHP_EOL;
 if ($response->statusCode === 200) {
   echo 'body: ' . $response->body . PHP_EOL;
   echo 'original status: ' . $response->headers->original_status . PHP_EOL;
-  echo 'crawlbase status: ' . $response->headers->pc_status . PHP_EOL;
+  echo 'crawlbase status: ' . $response->headers->cb_status . PHP_EOL;
   echo 'rid: ' . $response->headers->rid . PHP_EOL;
   echo 'url: ' . $response->headers->url . PHP_EOL;
   echo 'stored date: ' . $response->headers->stored_at . PHP_EOL;
@@ -287,7 +288,7 @@ foreach ($items as $item) {
   echo 'body: ' . $item->body . PHP_EOL;
   echo 'stored at: ' . $item->stored_at . PHP_EOL;
   echo 'original status: ' . $item->original_status . PHP_EOL;
-  echo 'crawlbase status: ' . $item->pc_status . PHP_EOL;
+  echo 'crawlbase status: ' . $item->cb_status . PHP_EOL;
   echo 'rid: ' . $item->rid . PHP_EOL;
   echo 'url: ' . $item->url . PHP_EOL;
   echo PHP_EOL;

--- a/src/base-api.php
+++ b/src/base-api.php
@@ -127,6 +127,10 @@ class BaseAPI {
 
     curl_close($curl);
 
+    if (is_array($this->response) && isset($this->response['headers']) && is_array($this->response['headers'])) {
+      $this->normalizeCrawlbaseStatusHeaders($this->response['headers']);
+    }
+
     // Cast to object for easier access
     $this->response = (object) $this->response;
     if (isset($this->response->headers)) {
@@ -161,7 +165,7 @@ class BaseAPI {
     $json = json_decode($this->response['body']);
     if (!empty($json->original_status)) {
       $this->response['headers']['original_status'] = $json->original_status;
-      $this->response['headers']['pc_status'] = $json->pc_status;
+      $this->assignCrawlbaseStatus($this->response['headers'], $json);
       $this->response['headers']['url'] = $json->url;
     }
     if (!empty($json->remaining_requests)) {
@@ -172,6 +176,59 @@ class BaseAPI {
     } else {
       $this->response['json'] = $json;
     }
+  }
+
+  /**
+   * Prefer cb_status, fall back to deprecated pc_status, and dual-write both.
+   *
+   * @param array|object $target Destination that will receive both status keys
+   * @param array|object $source Source that may contain cb_status and/or pc_status
+   */
+  protected function assignCrawlbaseStatus(&$target, $source) {
+    $cbStatus = $this->readStatusValue($source, 'cb_status');
+    $pcStatus = $this->readStatusValue($source, 'pc_status');
+    $status = $cbStatus !== null ? $cbStatus : $pcStatus;
+
+    if ($status === null) {
+      return;
+    }
+
+    if (is_array($target)) {
+      $target['cb_status'] = $status;
+      $target['pc_status'] = $status; // deprecated alias
+    } else {
+      $target->cb_status = $status;
+      $target->pc_status = $status; // deprecated alias
+    }
+  }
+
+  /**
+   * Dual-write cb_status / pc_status on response headers after HTTP metadata is collected.
+   *
+   * @param array $headers
+   */
+  protected function normalizeCrawlbaseStatusHeaders(array &$headers) {
+    $this->assignCrawlbaseStatus($headers, $headers);
+  }
+
+  /**
+   * @param array|object $source
+   * @param string $key
+   * @return mixed|null
+   */
+  private function readStatusValue($source, $key) {
+    if (is_array($source)) {
+      if (!array_key_exists($key, $source) || $source[$key] === '' || $source[$key] === null) {
+        return null;
+      }
+      return $source[$key];
+    }
+
+    if (!is_object($source) || !isset($source->$key) || $source->$key === '') {
+      return null;
+    }
+
+    return $source->$key;
   }
 
 }

--- a/src/storage-api.php
+++ b/src/storage-api.php
@@ -51,7 +51,7 @@ class StorageAPI extends BaseAPI {
 
     $this->setEndpoint('storage/bulk');
     $this->request($options, $data);
-    return $this->response->json;
+    return $this->aliasStatusOnStorageItems($this->response->json);
   }
 
   public function rids($limit = -1, array $options = array()) {
@@ -67,5 +67,29 @@ class StorageAPI extends BaseAPI {
     $this->setEndpoint('storage/total_count');
     $this->request($options);
     return $this->response->json->totalCount;
+  }
+
+  /**
+   * Ensure storage items expose cb_status with pc_status kept as a deprecated alias.
+   *
+   * @param mixed $items
+   * @return mixed
+   */
+  private function aliasStatusOnStorageItems($items) {
+    if (is_array($items)) {
+      foreach ($items as &$item) {
+        if (is_object($item) || is_array($item)) {
+          $this->assignCrawlbaseStatus($item, $item);
+        }
+      }
+      unset($item);
+      return $items;
+    }
+
+    if (is_object($items)) {
+      $this->assignCrawlbaseStatus($items, $items);
+    }
+
+    return $items;
   }
 }


### PR DESCRIPTION
## Summary

- Introduce `cb_status` as the preferred Crawlbase status field and deprecate `pc_status`.
- Prefer `cb_status` from API headers/JSON when present; fall back to `pc_status` (current API behavior) and dual-write both on responses so existing consumer code keeps working.
- Apply the same aliasing to Storage bulk items; update README examples and document the change in CHANGELOG as `3.1.0`.

This is a non-breaking release. `pc_status` remains available as a deprecated alias and is planned for removal in a future major version.

## Test plan

- [ ] Crawling API HTML response: confirm `$response->headers->cb_status` and `$response->headers->pc_status` are both set and equal when the API returns only `pc_status`
- [ ] Crawling API with `format=json`: confirm status is resolved from the JSON envelope the same way
- [ ] Storage get by URL/RID: confirm both status fields are present on response headers
- [ ] Storage bulk: confirm each item exposes `cb_status` and keeps `pc_status`
- [ ] Existing code using `pc_status` continues to work without changes
- [ ] README examples render correctly and mention the deprecation note
