### PR TITLE
Deprecate pc_status and introduce preferred cb_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Only major versions or things to communicate are written here. Minor changes or bug fixes might not appear in the changelog.
 
+## 3.1.0
+
+Introduces `cb_status` as the preferred Crawlbase status field on response headers (and Storage bulk items).  
+`pc_status` is deprecated but still supported as a temporary alias of the resolved status value. When both `cb_status` and `pc_status` are present, `cb_status` takes priority. See the README migration note for upgrading from `pc_status` to `cb_status`.
+
 ## 3.0.0
 
 Adds Screenshots API and Storage API.  

--- a/README.md
+++ b/README.md
@@ -324,4 +324,4 @@ If you have questions or need help using the library, please open an issue or [c
 
 ---
 
-Copyright 2025 Crawlbase
+Copyright 2026 Crawlbase

--- a/README.md
+++ b/README.md
@@ -131,13 +131,27 @@ if ($response->statusCode === 200) {
 
 ## Original status
 
-You can always get the original status and crawlbase status from the response. Read the [Crawlbase documentation](https://crawlbase.com/docs/crawling-api/) to learn more about those status.
+You can always get the original status and Crawlbase status from the response. Read the [Crawlbase documentation](https://crawlbase.com/docs/crawling-api/) to learn more about those status.
+
+Prefer `cb_status` for the Crawlbase status. `pc_status` is deprecated but still supported temporarily as an alias of the same resolved value. When both headers are present, `cb_status` takes priority.
 
 ```php
 $response = $api->get('https://craiglist.com');
 echo $response->headers->original_status . PHP_EOL;
-echo $response->headers->pc_status . PHP_EOL;
+echo $response->headers->cb_status . PHP_EOL;
 ```
+
+### Migrating from `pc_status` to `cb_status`
+
+```php
+// Before (deprecated)
+echo $response->headers->pc_status;
+
+// After (preferred)
+echo $response->headers->cb_status;
+```
+
+During the deprecation period, both properties remain available and are kept in sync by the library.
 
 ## Scraper API
 
@@ -238,7 +252,7 @@ echo 'status code: ' . $response->statusCode . PHP_EOL;
 if ($response->statusCode === 200) {
   echo 'body: ' . $response->body . PHP_EOL;
   echo 'original status: ' . $response->headers->original_status . PHP_EOL;
-  echo 'crawlbase status: ' . $response->headers->pc_status . PHP_EOL;
+  echo 'crawlbase status: ' . $response->headers->cb_status . PHP_EOL;
   echo 'rid: ' . $response->headers->rid . PHP_EOL;
   echo 'url: ' . $response->headers->url . PHP_EOL;
   echo 'stored date: ' . $response->headers->stored_at . PHP_EOL;
@@ -254,7 +268,7 @@ echo 'status code: ' . $response->statusCode . PHP_EOL;
 if ($response->statusCode === 200) {
   echo 'body: ' . $response->body . PHP_EOL;
   echo 'original status: ' . $response->headers->original_status . PHP_EOL;
-  echo 'crawlbase status: ' . $response->headers->pc_status . PHP_EOL;
+  echo 'crawlbase status: ' . $response->headers->cb_status . PHP_EOL;
   echo 'rid: ' . $response->headers->rid . PHP_EOL;
   echo 'url: ' . $response->headers->url . PHP_EOL;
   echo 'stored date: ' . $response->headers->stored_at . PHP_EOL;
@@ -287,7 +301,7 @@ foreach ($items as $item) {
   echo 'body: ' . $item->body . PHP_EOL;
   echo 'stored at: ' . $item->stored_at . PHP_EOL;
   echo 'original status: ' . $item->original_status . PHP_EOL;
-  echo 'crawlbase status: ' . $item->pc_status . PHP_EOL;
+  echo 'crawlbase status: ' . $item->cb_status . PHP_EOL;
   echo 'rid: ' . $item->rid . PHP_EOL;
   echo 'url: ' . $item->url . PHP_EOL;
   echo PHP_EOL;

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "php": ">=5.4.0"
   },
   "scripts": {
-    "test": "php test.php"
+    "test": "php test.php",
+    "test:unit": "php tests/status-normalization-test.php"
   }
 }

--- a/src/base-api.php
+++ b/src/base-api.php
@@ -103,6 +103,8 @@ class BaseAPI {
         $this->parseJsonResponse();
       }
 
+      $this->normalizeCrawlbaseStatusHeaders();
+
       if ($this->debug || $this->advDebug) {
         $info = curl_getinfo($curl);
         echo '<pre>';
@@ -161,9 +163,19 @@ class BaseAPI {
     $json = json_decode($this->response['body']);
     if (!empty($json->original_status)) {
       $this->response['headers']['original_status'] = $json->original_status;
-      $this->response['headers']['pc_status'] = $json->pc_status;
       $this->response['headers']['url'] = $json->url;
     }
+
+    $status = $this->resolveCrawlbaseStatus(
+      isset($json->cb_status) ? $json->cb_status : null,
+      isset($json->pc_status) ? $json->pc_status : null
+    );
+    if ($status !== null) {
+      $this->response['headers']['cb_status'] = $status;
+      // pc_status is deprecated; kept as an alias of cb_status for backward compatibility.
+      $this->response['headers']['pc_status'] = $status;
+    }
+
     if (!empty($json->remaining_requests)) {
       $this->response['headers']['remaining_requests'] = $json->remaining_requests;
     }
@@ -172,6 +184,104 @@ class BaseAPI {
     } else {
       $this->response['json'] = $json;
     }
+  }
+
+  /**
+   * Prefer cb_status; fall back to deprecated pc_status. Mirror the resolved value onto both.
+   * pc_status will be removed in a future major release.
+   */
+  protected function normalizeCrawlbaseStatusHeaders() {
+    if (!isset($this->response['headers']) || !is_array($this->response['headers'])) {
+      return;
+    }
+
+    $headers = &$this->response['headers'];
+    $status = $this->resolveCrawlbaseStatus(
+      isset($headers['cb_status']) ? $headers['cb_status'] : null,
+      isset($headers['pc_status']) ? $headers['pc_status'] : null
+    );
+
+    if ($status === null) {
+      return;
+    }
+
+    $headers['cb_status'] = $status;
+    // pc_status is deprecated; kept as an alias of cb_status for backward compatibility.
+    $headers['pc_status'] = $status;
+  }
+
+  /**
+   * Prefer cb_status; fall back to deprecated pc_status. Mirror the resolved value onto both
+   * properties when either is present. Used for Storage bulk JSON items.
+   * pc_status will be removed in a future major release.
+   *
+   * @param object|array $object
+   * @return object|array
+   */
+  protected function normalizeCrawlbaseStatusObject($object) {
+    if (is_object($object)) {
+      $status = $this->resolveCrawlbaseStatus(
+        isset($object->cb_status) ? $object->cb_status : null,
+        isset($object->pc_status) ? $object->pc_status : null
+      );
+      if ($status !== null) {
+        $object->cb_status = $status;
+        // pc_status is deprecated; kept as an alias of cb_status for backward compatibility.
+        $object->pc_status = $status;
+      }
+      return $object;
+    }
+
+    if (is_array($object)) {
+      $status = $this->resolveCrawlbaseStatus(
+        isset($object['cb_status']) ? $object['cb_status'] : null,
+        isset($object['pc_status']) ? $object['pc_status'] : null
+      );
+      if ($status !== null) {
+        $object['cb_status'] = $status;
+        // pc_status is deprecated; kept as an alias of cb_status for backward compatibility.
+        $object['pc_status'] = $status;
+      }
+      return $object;
+    }
+
+    return $object;
+  }
+
+  /**
+   * @param mixed $cbStatus Preferred status (cb_status)
+   * @param mixed $pcStatus Deprecated status (pc_status)
+   * @return mixed|null Resolved status, or null when neither is present
+   */
+  protected function resolveCrawlbaseStatus($cbStatus, $pcStatus) {
+    if ($this->isCrawlbaseStatusPresent($cbStatus)) {
+      return $this->castCrawlbaseStatusValue($cbStatus);
+    }
+    if ($this->isCrawlbaseStatusPresent($pcStatus)) {
+      return $this->castCrawlbaseStatusValue($pcStatus);
+    }
+
+    return null;
+  }
+
+  /**
+   * @param mixed $value
+   * @return bool
+   */
+  protected function isCrawlbaseStatusPresent($value) {
+    return $value !== null && $value !== '';
+  }
+
+  /**
+   * @param mixed $value
+   * @return mixed
+   */
+  protected function castCrawlbaseStatusValue($value) {
+    if (is_numeric($value)) {
+      return (int) $value;
+    }
+
+    return $value;
   }
 
 }

--- a/src/storage-api.php
+++ b/src/storage-api.php
@@ -51,6 +51,17 @@ class StorageAPI extends BaseAPI {
 
     $this->setEndpoint('storage/bulk');
     $this->request($options, $data);
+
+    $json = $this->response->json;
+    if (is_array($json)) {
+      foreach ($json as $index => $item) {
+        $json[$index] = $this->normalizeCrawlbaseStatusObject($item);
+      }
+      $this->response->json = $json;
+    } else if (is_object($json)) {
+      $this->response->json = $this->normalizeCrawlbaseStatusObject($json);
+    }
+
     return $this->response->json;
   }
 

--- a/tests/status-normalization-test.php
+++ b/tests/status-normalization-test.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Offline unit tests for cb_status / pc_status normalization.
+ * Run: php tests/status-normalization-test.php
+ */
+
+require_once dirname(__DIR__) . '/src/base-api.php';
+
+class StatusNormalizationTestAPI extends Crawlbase\BaseAPI {
+  public function __construct() {
+    // Skip real token validation for offline tests.
+  }
+
+  public function exposeNormalizeHeaders(array $headers) {
+    $this->response = array('headers' => $headers);
+    $this->normalizeCrawlbaseStatusHeaders();
+    return $this->response['headers'];
+  }
+
+  public function exposeNormalizeObject($object) {
+    return $this->normalizeCrawlbaseStatusObject($object);
+  }
+
+  public function exposeParseJsonBody($body) {
+    $this->response = array(
+      'headers' => array(),
+      'body' => $body,
+    );
+    $this->parseJsonResponse();
+    $this->normalizeCrawlbaseStatusHeaders();
+    return $this->response['headers'];
+  }
+}
+
+$api = new StatusNormalizationTestAPI();
+$passed = 0;
+$failed = 0;
+
+function assert_true($condition, $message) {
+  global $passed, $failed;
+  if ($condition) {
+    echo "PASS: $message\n";
+    $passed++;
+  } else {
+    echo "FAIL: $message\n";
+    $failed++;
+  }
+}
+
+// 1. Response contains only cb_status
+$headers = $api->exposeNormalizeHeaders(array('cb_status' => 200));
+assert_true(isset($headers['cb_status']) && $headers['cb_status'] === 200, 'only cb_status sets cb_status');
+assert_true(isset($headers['pc_status']) && $headers['pc_status'] === 200, 'only cb_status aliases pc_status');
+
+// 2. Response contains only pc_status
+$headers = $api->exposeNormalizeHeaders(array('pc_status' => 404));
+assert_true(isset($headers['cb_status']) && $headers['cb_status'] === 404, 'only pc_status sets cb_status');
+assert_true(isset($headers['pc_status']) && $headers['pc_status'] === 404, 'only pc_status keeps pc_status');
+
+// 3. Both present — cb_status takes priority
+$headers = $api->exposeNormalizeHeaders(array('cb_status' => 200, 'pc_status' => 500));
+assert_true($headers['cb_status'] === 200, 'both present: cb_status wins on cb_status');
+assert_true($headers['pc_status'] === 200, 'both present: resolved value mirrored to pc_status');
+
+// 4. Neither header
+$headers = $api->exposeNormalizeHeaders(array('url' => 'https://example.com'));
+assert_true(!isset($headers['cb_status']), 'neither present: cb_status unset');
+assert_true(!isset($headers['pc_status']), 'neither present: pc_status unset');
+
+// 5. Legacy pc_status behavior must keep working (via alias from cb-only and pc-only)
+$headers = $api->exposeNormalizeHeaders(array('pc_status' => 301));
+assert_true($headers['pc_status'] === 301, 'legacy: pc_status still readable when only pc_status received');
+$headers = $api->exposeNormalizeHeaders(array('cb_status' => 302));
+assert_true($headers['pc_status'] === 302, 'legacy: pc_status still readable when only cb_status received');
+
+// Empty string treated as absent
+$headers = $api->exposeNormalizeHeaders(array('cb_status' => '', 'pc_status' => 200));
+assert_true($headers['cb_status'] === 200 && $headers['pc_status'] === 200, 'empty cb_status falls back to pc_status');
+
+// Numeric string cast
+$headers = $api->exposeNormalizeHeaders(array('cb_status' => '200'));
+assert_true($headers['cb_status'] === 200 && is_int($headers['cb_status']), 'numeric string cb_status cast to int');
+
+// JSON path: only cb_status
+$headers = $api->exposeParseJsonBody(json_encode(array('cb_status' => 200, 'url' => 'https://example.com')));
+assert_true(isset($headers['cb_status']) && $headers['cb_status'] === 200, 'JSON only cb_status sets cb_status');
+assert_true(isset($headers['pc_status']) && $headers['pc_status'] === 200, 'JSON only cb_status aliases pc_status');
+
+// JSON path: only pc_status (with original_status for typical API shape)
+$headers = $api->exposeParseJsonBody(json_encode(array(
+  'original_status' => 200,
+  'pc_status' => 404,
+  'url' => 'https://example.com',
+)));
+assert_true($headers['cb_status'] === 404 && $headers['pc_status'] === 404, 'JSON only pc_status resolves both');
+assert_true(isset($headers['original_status']) && $headers['original_status'] === 200, 'JSON original_status still copied');
+
+// JSON path: both — cb wins
+$headers = $api->exposeParseJsonBody(json_encode(array(
+  'cb_status' => 200,
+  'pc_status' => 500,
+  'original_status' => 200,
+  'url' => 'https://example.com',
+)));
+assert_true($headers['cb_status'] === 200 && $headers['pc_status'] === 200, 'JSON both: cb_status wins');
+
+// Bulk item object normalization
+$item = (object) array('pc_status' => 403, 'rid' => 'abc');
+$item = $api->exposeNormalizeObject($item);
+assert_true($item->cb_status === 403 && $item->pc_status === 403, 'bulk object: only pc_status aliases both');
+
+$item = (object) array('cb_status' => 200, 'pc_status' => 500, 'rid' => 'abc');
+$item = $api->exposeNormalizeObject($item);
+assert_true($item->cb_status === 200 && $item->pc_status === 200, 'bulk object: cb_status wins');
+
+$item = (object) array('rid' => 'abc');
+$item = $api->exposeNormalizeObject($item);
+assert_true(!isset($item->cb_status) && !isset($item->pc_status), 'bulk object: neither leaves unset');
+
+$nonObject = 'skip';
+assert_true($api->exposeNormalizeObject($nonObject) === 'skip', 'non-object bulk value left unchanged');
+
+echo "\nPassed: $passed, Failed: $failed\n";
+exit($failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Introduce `cb_status` as the preferred Crawlbase status field on response headers and Storage bulk items.
- Deprecate `pc_status` while keeping it supported as a temporary alias of the resolved status value for backward compatibility.
- When both `cb_status` and `pc_status` are present, prefer `cb_status` and mirror the resolved value onto both fields.
- Document the change in the README (including a migration note) and Changelog for `3.1.0`.
- Add offline unit tests covering only-`cb_status`, only-`pc_status`, both present, neither present, and legacy `pc_status` access.

## Motivation

The Crawlbase API is moving toward `cb_status` as the canonical status header/field name. Existing library users may still read `pc_status`, so this release adopts the new preferred name without breaking current integrations.

## Behavior

| API / library input | Public result |
|---------------------|---------------|
| Only `cb_status` | Both `cb_status` and `pc_status` set to that value |
| Only `pc_status` | Both set to that value (`cb_status` available; `pc_status` unchanged in meaning) |
| Both present | Resolved value is `cb_status` for both |
| Neither present | Both left unset |

Runtime deprecation warnings are intentionally not emitted (headers remain plain objects), matching the library’s existing docs-only deprecation style.

## Versioning

This is a **minor** release (`3.1.0`): additive public API (`cb_status`) with a documented deprecation of `pc_status`. A future major release may remove the `pc_status` alias after a migration window.

## Test plan

- [x] Run offline unit tests: `composer test:unit` (or `php tests/status-normalization-test.php`)
- [ ] Confirm response with only `cb_status` exposes `$response->headers->cb_status` and aliased `pc_status`
- [ ] Confirm response with only `pc_status` still works for existing `$response->headers->pc_status` usage
- [ ] Confirm response with both headers prefers `cb_status`
- [ ] Confirm response with neither header leaves both unset
- [ ] Confirm Storage bulk items receive the same `cb_status` / `pc_status` aliasing
- [ ] Optional: smoke-test against a live Crawlbase token via `php test.php`
